### PR TITLE
fix(seo): stop double-escaping post titles & canonical to LinkedIn

### DIFF
--- a/src/_includes/base.njk
+++ b/src/_includes/base.njk
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% if pageTitle %}{{ pageTitle }} — {{ site.title }}{% else %}{{ site.title }}{% endif %}</title>
     <meta name="description" content="{{ pageDescription or site.description }}">
-    <link rel="canonical" href="{{ (page.url | absoluteUrl(site.url)) }}">
+    <link rel="canonical" href="{{ canonicalUrl or (page.url | absoluteUrl(site.url)) }}">
     <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ site.feedUrl }}">
     <link rel="stylesheet" href="/assets/style.css">
     <meta property="og:type" content="{% if ogType %}{{ ogType }}{% else %}website{% endif %}">

--- a/src/posts.njk
+++ b/src/posts.njk
@@ -6,8 +6,9 @@ pagination:
 permalink: "/posts/{{ issue.slug }}/"
 layout: post.njk
 eleventyComputed:
-  pageTitle: "{{ issue.title }}"
-  pageDescription: "{{ issue.bodyHtml | excerpt(180) }}"
+  pageTitle: "{{ issue.title | safe }}"
+  pageDescription: "{{ issue.bodyHtml | excerpt(180) | safe }}"
   ogType: article
   ogImage: "{{ issue.image }}"
+  canonicalUrl: "{{ issue.sourceUrl }}"
 ---


### PR DESCRIPTION
## Summary
- `<title>` / `og:title` / `og:description` on post pages were rendering double-encoded entities (e.g. `You&amp;#39;re Not T-Shaped...` instead of `You&#39;re Not T-Shaped...`). Root cause: `eleventyComputed` template strings in `src/posts.njk` were escaping once on substitution, then `base.njk` escaped a second time. Marked the substituted values `| safe` so the layout does the single, final escape.
- Set `<link rel="canonical">` on post pages to the originating LinkedIn post URL (`issue.sourceUrl`) so search engines treat LinkedIn as the source-of-truth. Index and other pages keep self-canonical behaviour.
- Retroactive by design: posts are generated from `src/_data/archive.json` on every build, `_site/` is gitignored, and the hourly deploy cron republishes the lot — so this single PR fixes all 22 existing posts on the next deploy.

## Test plan
- [x] `npm run build` clean (24 files written)
- [x] `grep -rl '&amp;#39;' _site/posts/` → 0 matches
- [x] `grep -rl '&amp;quot;' _site/posts/` → 0 matches
- [x] T-Shaped post `<title>` now `You&#39;re Not T-Shaped...` (single encoding)
- [x] T-Shaped post `<link rel="canonical">` points at `https://www.linkedin.com/pulse/youre-t-shaped...`
- [x] `_site/index.html` canonical still `https://blog.cns.me/`
- [ ] Post-deploy: confirm live page view-source shows `&#39;` (not `&amp;#39;`) and canonical points at LinkedIn