### PR TITLE
Tidy homepage hero: drop image caption, extend lead description

### DIFF
--- a/src/_data/issues.js
+++ b/src/_data/issues.js
@@ -70,6 +70,7 @@ export default function () {
         imgCaption: e.imgCaption || null,
         bodyHtml,
         dek: dekFrom(bodyHtml),
+        leadDek: dekFrom(bodyHtml, 420),
         readingTime: readingTime(bodyHtml),
         fallbackFill: fallbackFill(e.slug),
       };

--- a/src/index.njk
+++ b/src/index.njk
@@ -27,12 +27,7 @@ screenLabel: Index
     <h2 class="post-lead-title">
       <a href="/posts/{{ lead.slug }}/">{{ lead.title }}</a>
     </h2>
-    {% if lead.dek %}<p class="post-lead-dek">{{ lead.dek }}</p>{% endif %}
-    {% if lead.imgCaption %}
-      <blockquote class="post-lead-excerpt">
-        <p>{{ lead.imgCaption }}</p>
-      </blockquote>
-    {% endif %}
+    {% if lead.leadDek %}<p class="post-lead-dek">{{ lead.leadDek }}</p>{% endif %}
     <div class="post-meta-bot">
       <a href="/posts/{{ lead.slug }}/" class="post-lead-cta">Read in full →</a>
       <span class="post-sep">|</span>


### PR DESCRIPTION
The AI-generated image caption was rendered as a blockquote under the lead post on the homepage, which looked awkward sitting beneath the short description.

## Changes
- Remove the `imgCaption` blockquote from the homepage hero (`src/index.njk`). The caption still appears on individual post pages — only the homepage summary is affected.
- Add a longer `leadDek` (420 chars vs the standard 220) in `src/_data/issues.js` and use it for the hero, so the extended description fills the space cleanly instead of the cut-off short version.

## Verification
`npm run build` succeeds; the rendered `_site/index.html` shows the extended description and no `post-lead-excerpt` blockquote.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfGarT2Fra21mGhrgtYk8u)_