### PR TITLE
Fix HTML entities leaking into home page snippets

### DIFF
--- a/src/_data/issues.js
+++ b/src/_data/issues.js
@@ -8,9 +8,36 @@ function fallbackFill(slug = "") {
   return FILLS[h % FILLS.length];
 }
 
+const NAMED_ENTITIES = {
+  amp: "&",
+  lt: "<",
+  gt: ">",
+  quot: '"',
+  apos: "'",
+  nbsp: " ",
+};
+
+function decodeEntities(text) {
+  return text.replace(/&(#x?[0-9a-f]+|[a-z]+);/gi, (match, body) => {
+    if (body[0] === "#") {
+      const code =
+        body[1] === "x" || body[1] === "X"
+          ? parseInt(body.slice(2), 16)
+          : parseInt(body.slice(1), 10);
+      return Number.isFinite(code) ? String.fromCodePoint(code) : match;
+    }
+    const named = NAMED_ENTITIES[body.toLowerCase()];
+    return named !== undefined ? named : match;
+  });
+}
+
 function plainText(html) {
-  return String(html || "")
-    .replace(/<[^>]+>/g, " ")
+  return decodeEntities(
+    String(html || "")
+      .replace(/<[^>]+>/g, " ")
+      .replace(/\s+/g, " ")
+      .trim()
+  )
     .replace(/\s+/g, " ")
     .trim();
 }


### PR DESCRIPTION
## Problem

Home page snippets (deks) showed raw HTML entities, e.g. `Institutional Memory &amp; AI` instead of `Institutional Memory & AI`.

## Cause

`plainText()` in `src/_data/issues.js` stripped HTML tags but left HTML entities (like `&amp;`) intact. The generated dek therefore contained a literal `&amp;`. Nunjucks then auto-escaped the ampersand again when rendering `{{ post.dek }}`, producing `&amp;amp;` in the HTML source, which the browser renders visibly as `&amp;`.

## Fix

Decode HTML entities (named + numeric/hex) when building the plain text used for deks and reading time. The dek now holds a real `&`, which Nunjucks escapes to `&amp;` in the source and the browser renders as `&`.

Verified against the built `_site/index.html` — the offending snippet now renders correctly.

---
_Generated by [Claude Code](https://claude.ai/code/session_014aSwcKGPnZeqkEDDGKT6k8)_